### PR TITLE
u-boot: Fix for bootargs

### DIFF
--- a/common/board_r.c
+++ b/common/board_r.c
@@ -864,7 +864,7 @@ int board_set_boot_device(void)
 #ifdef CONFIG_ANDROID_SUPPORT
 	setenv("bootargs_adv", buf);
 #else
-	setenv("bootargs", buf);
+	setenv("version", buf);
 #endif
 	// check emmc exists or not
 	emmc_exist = check_emmc_exist();


### PR DESCRIPTION
As the adv version and u-boot version is passed to the bootargs, the default value of bootargs is getting overwritten every time while giving a reset. This could help them to get the values into other string.